### PR TITLE
Adding support for --use_aiguard option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ This utility measures the accuracy of detecting malicious versus benign prompts.
       - **Base URL** - The full base URL for Prompt Guard (e.g. "https://prompt-guard.aws.us.pangea.cloud"). This must be set using the `PANGEA_BASE_URL` environment variable.
       - **Default Token** - API access token for the service endpoints.
 
-      Assign these values to environment variables, for example:
+      Assign these values to environment variables (PANGEA_AI_GUARD_TOKEN only needed for --use_ai_guard), for example:
 
       ```bash
       export PANGEA_BASE_URL="https://prompt-guard.<domain>"
       export PANGEA_PROMPT_GUARD_TOKEN="<default-token-value>"
+      export PANGEA_AI_GUARD_TOKEN="<default-token-value>"
       ```
 
       _or_
@@ -68,6 +69,8 @@ usage: poetry run python prompt_lab.py [-h]
                      [--rps RPS]
                      [--max_poll_attempts MAX_POLL_ATTEMPTS]
                      [--print_label_stats]
+                     [--use_ai_guard]
+                     [--topics]
 ```
 
 ## Important Flags
@@ -120,16 +123,21 @@ usage: poetry run python prompt_lab.py [-h]
    - `--rps`: Requests per second (default: 1.0).
    - `--max_poll_attempts`: Maximum retries for async requests (default: 10).
 
-## Example Commands
+
+7) **Using AI Guard API**
+   - `--use_ai_guard`: Use AI Guard service instead of Prompt Guard. This will use the AI Guard API with a forced recipe of malicious prompt and topic detectors with default topics: toxicity, self-harm and violence, roleplay, weapons, criminal conduct, sexual.
+   - `--topics`: Comma-separated list of topics to use with AI Guard. Default: 'toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual'.
+
+   NOTE: Ensure that PANGEA_AI_GUARD_TOKEN is set to a valid AI Guard token value.
 
 1) **Single Prompt:**
    ```bash
    poetry run python prompt_lab.py --prompt "Ignore previous instructions..." --verbose
    ```
 
-2) **JSON File (tps/tns):**
+2) **JSONL File (tps/tns):**
    ```bash
-   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --verbose --rps 16
+   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --rps 16
    ```
 
 3) **Text File (All True Positives):**
@@ -150,6 +158,16 @@ usage: poetry run python prompt_lab.py [-h]
 6) **Specify Analyzers:**
    ```bash
    poetry run python prompt_lab.py --input_file data/spml_dataset.csv --analyzers PA2001,PA2002 --verbose
+   ```
+
+7) **Use AI Guard:**
+   ```bash
+   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --use_ai_guard --rps 16
+   ```
+
+8) **Specify AI Guard Topics:**
+   ```bash
+   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --use_ai_guard --topics "toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual" --rps 16
    ```
 
 ## Sample Dataset

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ usage: poetry run python prompt_lab.py [-h]
 7) **Using AI Guard API**
    - `--use_ai_guard`: Use AI Guard service instead of Prompt Guard. This will use the AI Guard API with a forced recipe of malicious prompt and topic detectors with default topics: toxicity, self-harm and violence, roleplay, weapons, criminal conduct, sexual.
    - `--topics`: Comma-separated list of topics to use with AI Guard. Default: 'toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual'.
+   - `--threshold`: Float that specifies the confidence threshold for the topic match.  Default: 0.5.
 
    NOTE: Ensure that PANGEA_AI_GUARD_TOKEN is set to a valid AI Guard token value.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ usage: poetry run python prompt_lab.py [-h]
                      [--print_label_stats]
                      [--use_ai_guard]
                      [--topics]
+                     [--threshold]
 ```
 
 ## Important Flags
@@ -170,6 +171,10 @@ usage: poetry run python prompt_lab.py [-h]
    poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --use_ai_guard --topics "toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual" --rps 16
    ```
 
+8) **Specify AI Guard Topics and threshold:**
+   ```bash
+   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --use_ai_guard --topics "toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual" --threshold 0.8 --rps 16
+   ```
 ## Sample Dataset
 
 The sample dataset (`data/test_dataset.jsonl`) contains:

--- a/prompt_lab.py
+++ b/prompt_lab.py
@@ -265,7 +265,7 @@ class PromptDetectionManager:
         analyzers_list=None,
         use_ai_guard=False,
         topics=None,        
-        threshold=0.5, 
+        threshold=None, 
     ):
         self.args = args # Should switch to using this to make it easier to pass around
         self.rps = rps
@@ -740,21 +740,35 @@ class PromptDetectionManager:
     def ai_guard_service(
             self, 
             messages, 
-            topics=[
-                "toxicity",
-                "self-harm and violence",
-                "roleplay",
-                "weapons",
-                "criminal conduct",
-                "sexual"
-            ],
-            threshold=0.5
+            topics=None, 
+            threshold=None
             ):
         """
         Submit a single prompt to the AI Guard service using the full messages array.
         The recipe can be specified, defaulting to "pangea_prompt_guard".
         """
         endpoint = "/v1/text/guard"
+
+        if not topics:
+            if self.topics:
+                topics = self.topics
+            else:
+                topics=[
+                    "toxicity",
+                    "self-harm and violence",
+                    "roleplay",
+                    "weapons",
+                    "criminal conduct",
+                    "sexual"
+                ]
+        # Topics have to be lowercased:
+        topics = [topic.lower() for topic in topics]
+        if not threshold:
+            if self.threshold:
+                threshold = self.threshold
+            else:
+                threshold=0.5
+
         overrides = {
             "ignore_recipe": True,
             "prompt_injection": {
@@ -1183,12 +1197,12 @@ def main():
     )  # Use provided topics or default if not specified
     if args.use_ai_guard and not topics:
         topics = [
-            "Toxicity",
-            "Self-harm and violence",
-            "Roleplay",
-            "Weapons",
-            "Criminal conduct",
-            "Sexual"
+            "toxicity",
+            "self-harm and violence",
+            "roleplay",
+            "weapons",
+            "criminal conduct",
+            "sexual"
         ]
 
     pg = PromptDetectionManager(

--- a/prompt_lab.py
+++ b/prompt_lab.py
@@ -727,12 +727,12 @@ class PromptDetectionManager:
             self, 
             messages, 
             topics=[
-                "Toxicity",
-                "Self-harm and violence",
-                "Roleplay",
-                "Weapons",
-                "Criminal conduct",
-                "Sexual"
+                "toxicity",
+                "self-harm and violence",
+                "roleplay",
+                "weapons",
+                "criminal conduct",
+                "sexual"
             ]):
         """
         Submit a single prompt to the AI Guard service using the full messages array.
@@ -759,6 +759,8 @@ class PromptDetectionManager:
             "debug": self.verbose,
         }
 
+        if self.verbose:
+            print(f"\n{DARK_BLUE}Sending AI Guard request with data: {json.dumps(data, indent=4)}{RESET}")
         response = pangea_post_api(endpoint, data, self.ai_guard_token)
         if response.status_code == 202:
             print(f"\n{DARK_BLUE}Polling for AI Guard response...{RESET}")
@@ -1096,16 +1098,16 @@ def main():
         help=(
             "Use AI Guard service instead of Prompt Guard. "
             "This will use the AI Guard API with a forced recipe of malicious prompt and topic detectors with default topics: "
-            "Toxicity, Self-harm and violence, Roleplay, Weapons, Criminal conduct, Sexual."
+            "toxicity, self-harm and violence, roleplay, weapons, criminal conduct, sexual."
         ),
     )
     parser.add_argument(
         "--topics",
         type=str,
-        default="Toxicity,Self-harm and violence,Roleplay,Weapons,Criminal conduct,Sexual",
+        default="toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual",
         help=(
             "Comma-separated list of topics to use with AI Guard. "
-            "Default: 'Toxicity,Self-harm and violence,Roleplay,Weapons,Criminal conduct,Sexual'."
+            "Default: 'toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual'."
         ),
     )
 

--- a/prompt_lab.py
+++ b/prompt_lab.py
@@ -643,12 +643,24 @@ class PromptDetectionManager:
 
         detected = False
         detectors = []
+        detected_with_details = defaultdict(list)
         result = response.json().get("result", {})
 
         if self.use_ai_guard:
-            detected, detectors, _ = self.get_ai_guard_detected_details(response)
+            detected, detectors, detected_with_details = self.get_ai_guard_detected_details(response)
             if not detected:
                 detectors = ["None"]
+            else:
+                temp_detectors = []
+                for detector, details in detected_with_details.items():
+                    if isinstance(details, list):
+                        details_str = ", ".join(details)
+                    else:
+                        details_str = str(details)
+                    temp_detectors.append(f"{detector}: {details_str}")
+                if len(temp_detectors) == 0:
+                    temp_detectors = ["None"]
+                detectors = temp_detectors
         else:        
             detected = result.get("detected", False)
             detectors.append(result.get("analyzer", "None"))
@@ -1137,7 +1149,7 @@ def main():
         # If base_url contains "prompt-guard", replace it with "ai-guard".
         if base_url and "prompt-guard" in base_url:
             base_url = base_url.replace("prompt-guard", "ai-guard")
-            print(f"Using AI Guard base URL: {base_url}")
+            # print(f"Using AI Guard base URL: {base_url}")
         else:
             if base_url and "ai-guard" not in base_url:
                 print(

--- a/prompt_lab.py
+++ b/prompt_lab.py
@@ -264,7 +264,8 @@ class PromptDetectionManager:
         assume_tns=False,
         analyzers_list=None,
         use_ai_guard=False,
-        topics=None,         
+        topics=None,        
+        threshold=0.5, 
     ):
         self.args = args # Should switch to using this to make it easier to pass around
         self.rps = rps
@@ -279,6 +280,7 @@ class PromptDetectionManager:
         self.analyzers_list = analyzers_list
         self.use_ai_guard = use_ai_guard
         self.topics = topics
+        self.threshold = threshold
         self.prompt_guard_token = prompt_guard_token
         self.ai_guard_token = ai_guard_token
 
@@ -745,7 +747,9 @@ class PromptDetectionManager:
                 "weapons",
                 "criminal conduct",
                 "sexual"
-            ]):
+            ],
+            threshold=0.5
+            ):
         """
         Submit a single prompt to the AI Guard service using the full messages array.
         The recipe can be specified, defaulting to "pangea_prompt_guard".
@@ -760,7 +764,7 @@ class PromptDetectionManager:
             "topic": {
                 "disabled": False,
                 "action": "block",
-                "threshold": 0.5,
+                "threshold": threshold,
                 "topics": topics
             }
         }
@@ -1124,6 +1128,16 @@ def main():
         ),
     )
 
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help=(
+            "Threshold for topic detection confidence. "
+            "Only applies when using AI Guard with topics. Default: 0.5."
+        ),
+    )
+
     args = parser.parse_args()
 
     # If listing analyzers, just fetch and exit
@@ -1193,6 +1207,7 @@ def main():
         analyzers_list=analyzers_list,
         use_ai_guard=args.use_ai_guard,
         topics=topics, 
+        threshold=args.threshold,
     )
 
     process_all_prompts(args, pg)

--- a/prompt_lab.py
+++ b/prompt_lab.py
@@ -759,8 +759,9 @@ class PromptDetectionManager:
             "debug": self.verbose,
         }
 
-        if self.verbose:
-            print(f"\n{DARK_BLUE}Sending AI Guard request with data: {json.dumps(data, indent=4)}{RESET}")
+        # if self.verbose:
+        #     print(f"\n{DARK_BLUE}Sending AI Guard request with data: {json.dumps(data, indent=4)}{RESET}")
+
         response = pangea_post_api(endpoint, data, self.ai_guard_token)
         if response.status_code == 202:
             print(f"\n{DARK_BLUE}Polling for AI Guard response...{RESET}")

--- a/prompt_lab.py
+++ b/prompt_lab.py
@@ -1095,7 +1095,7 @@ def main():
         action="store_true",
         help=(
             "Use AI Guard service instead of Prompt Guard. "
-            "This will use the AI Guard recipe with default topics: "
+            "This will use the AI Guard API with a forced recipe of malicious prompt and topic detectors with default topics: "
             "Toxicity, Self-harm and violence, Roleplay, Weapons, Criminal conduct, Sexual."
         ),
     )


### PR DESCRIPTION
  --use_ai_guard        Use AI Guard service instead of Prompt Guard. This will use the AI Guard recipe with default topics: Toxicity, Self-harm and violence, Roleplay, Weapons, Criminal conduct, Sexual.
  --topics TOPICS       Comma-separated list of topics to use with AI Guard. Default: 'Toxicity,Self-harm and violence,Roleplay,Weapons,Criminal conduct,Sexual'.

You need to set the PANGEA_AI_GUARD_TOKEN  in addition to the PANGEA_PROMPT_GUARD_TOKEN.
PANGEA_BASE_URL should still point at prompt-guard, and the code will handle it.

NOTES: 
- If ai-guard API returns a 202, this does poll but for some reason ends up getting "unauthorized".  This bug needs to be looked into.  
- The README.md needs to be updated.
