### PR TITLE
Fixed topic names: 'self harm and violence' and 'criminal-conduct'.  …

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ usage: poetry run python prompt_lab.py [-h]
 
 
 7) **Using AI Guard API**
-   - `--use_ai_guard`: Use AI Guard service instead of Prompt Guard. This will use the AI Guard API with a forced recipe of malicious prompt and topic detectors with default topics: toxicity, self-harm and violence, roleplay, weapons, criminal conduct, sexual.
-   - `--topics`: Comma-separated list of topics to use with AI Guard. Default: 'toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual'.
+   - `--use_ai_guard`: Use AI Guard service instead of Prompt Guard. This will use the AI Guard API with a forced recipe of malicious prompt and topic detectors with default topics: toxicity, self harm and violence, roleplay, weapons, criminal-conduct, sexual.
+   - `--topics`: Comma-separated list of topics to use with AI Guard. Default: 'toxicity,self harm and violence,roleplay,weapons,criminal-conduct,sexual'.
    - `--threshold`: Float that specifies the confidence threshold for the topic match.  Default: 0.5.
 
    NOTE: Ensure that PANGEA_AI_GUARD_TOKEN is set to a valid AI Guard token value.
@@ -169,12 +169,12 @@ usage: poetry run python prompt_lab.py [-h]
 
 8) **Specify AI Guard Topics:**
    ```bash
-   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --use_ai_guard --topics "toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual" --rps 16
+   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --use_ai_guard --topics "toxicity,self harm and violence,roleplay,weapons,criminal-conduct,sexual" --rps 16
    ```
 
 8) **Specify AI Guard Topics and threshold:**
    ```bash
-   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --use_ai_guard --topics "toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual" --threshold 0.8 --rps 16
+   poetry run python prompt_lab.py --input_file data/test_dataset.jsonl --use_ai_guard --topics "toxicity,self harm and violence,roleplay,weapons,criminal-conduct,sexual" --threshold 0.8 --rps 16
    ```
 ## Sample Dataset
 

--- a/prompt_lab.py
+++ b/prompt_lab.py
@@ -755,10 +755,10 @@ class PromptDetectionManager:
             else:
                 topics=[
                     "toxicity",
-                    "self-harm and violence",
+                    "self harm and violence",
                     "roleplay",
                     "weapons",
-                    "criminal conduct",
+                    "criminal-conduct",
                     "sexual"
                 ]
         # Topics have to be lowercased:
@@ -1129,16 +1129,18 @@ def main():
         help=(
             "Use AI Guard service instead of Prompt Guard. "
             "This will use the AI Guard API with a forced recipe of malicious prompt and topic detectors with default topics: "
-            "toxicity, self-harm and violence, roleplay, weapons, criminal conduct, sexual."
+            "toxicity, self harm and violence, roleplay, weapons, criminal-conduct, sexual."
         ),
     )
     parser.add_argument(
         "--topics",
         type=str,
-        default="toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual",
+        default="toxicity,self harm and violence,roleplay,weapons,criminal-conduct,sexual",
         help=(
             "Comma-separated list of topics to use with AI Guard. "
-            "Default: 'toxicity,self-harm and violence,roleplay,weapons,criminal conduct,sexual'."
+            "Available topics: "
+            "'toxicity, self harm and violence, roleplay, weapons, criminal-conduct, sexual, financial-advice, legal-advice, religion, politics, health-coverage, negative-sentiment, gibberish'.  "
+            "Default: 'toxicity,self harm and violence,roleplay,weapons,criminal-conduct,sexual'"
         ),
     )
 
@@ -1193,15 +1195,15 @@ def main():
             analyzers_list = None
 
     topics = (
-        args.topics.split(",") if args.use_ai_guard and args.topics else None
+        [t.strip().lower() for t in args.topics.split(",")] if args.use_ai_guard and args.topics else None
     )  # Use provided topics or default if not specified
     if args.use_ai_guard and not topics:
         topics = [
             "toxicity",
-            "self-harm and violence",
+            "self harm and violence",
             "roleplay",
             "weapons",
-            "criminal conduct",
+            "criminal-conduct",
             "sexual"
         ]
 


### PR DESCRIPTION
…Also ensured there are no leading or trailing spaces in the topic names coming from the command line.